### PR TITLE
Fixed mount location for .ssh to match entry.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -d --name=ssh-agent docker-ssh-agent:latest
 Run a temporary container with volume mounted from host that includes your SSH keys. SSH key id_rsa will be added to ssh-agent (you can replace id_rsa with your key name):
 
 ```
-docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/root/.ssh -it docker-ssh-agent:latest ssh-add /root/.ssh/id_rsa
+docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/.ssh -it docker-ssh-agent:latest ssh-add /root/.ssh/id_rsa
 ```
 
 The ssh-agent container is now ready to use.

--- a/run.sh
+++ b/run.sh
@@ -73,6 +73,6 @@ echo -e "${bold}Launching ssh-agent container...${nc}"
 docker run -d --name=ssh-agent docker-ssh-agent:latest
 
 echo -e "Adding your ssh keys to the ssh-agent container..."
-docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/root/.ssh -it docker-ssh-agent:latest ssh-add /root/.ssh/id_rsa
+docker run --rm --volumes-from=ssh-agent -v ~/.ssh:/.ssh -it docker-ssh-agent:latest ssh-add /root/.ssh/id_rsa
 
 echo -e "${green}ssh-agent is now ready to use.${nc}"


### PR DESCRIPTION
In entry.sh, in order for it to fix the permissions and copy to `~/.ssh`, the mount must be on `/.ssh`, not `~/.ssh`.